### PR TITLE
srai correction in parse

### DIFF
--- a/src/Parsers/AIMLParser.php
+++ b/src/Parsers/AIMLParser.php
@@ -125,7 +125,7 @@ class AIMLParser {
      */
     protected function addSraiLink($category, $hash)
     {
-        $sraiHash = trim(strval($category->srai));
+        $sraiHash = trim(strval($category->template->srai));
         $this->linksTree[$hash] = $sraiHash;
     }
 

--- a/src/Parsers/Partials/Category.php
+++ b/src/Parsers/Partials/Category.php
@@ -24,7 +24,7 @@ class Category extends SimpleXMLElement {
      */
     public function hasSrai()
     {
-        return !empty($this->srai);
+        return !empty($this->template->srai);
     }
 
     /**


### PR DESCRIPTION
the SRAI tag is off the template object, not the category object.